### PR TITLE
[Feature] Update Notes API

### DIFF
--- a/src/common/helpers/status.ts
+++ b/src/common/helpers/status.ts
@@ -3,7 +3,7 @@ export const status = {
   REJECTED: 2,
   APPROVED: 3,
   REQUESTED: 4,
-  ELIGIBLILITY_CHECK: 5,
+  ELIGIBILITY_CHECK: 5,
   READY: 6,
   COMPLETED: 7,
   RETURNED: 8,

--- a/src/database/migrations/1664166644328-create_requests_table.ts
+++ b/src/database/migrations/1664166644328-create_requests_table.ts
@@ -90,6 +90,11 @@ export class CreateRequestTable1664166644328 implements MigrationInterface {
             default: 1,
           },
           {
+            name: 'notes',
+            type: 'text',
+            isNullable: false,
+          },
+          {
             name: 'created_at',
             type: 'timestamp(6)',
             default: 'CURRENT_TIMESTAMP(6)',

--- a/src/entities/request.entity.ts
+++ b/src/entities/request.entity.ts
@@ -52,6 +52,9 @@ export class Request {
   @Column({ type: 'int', nullable: false, default: 1 })
   public status?: number;
 
+  @Column({ type: 'text', nullable: true })
+  public notes?: string;
+
   @CreateDateColumn({ type: 'timestamp', nullable: false })
   public created_at?: Date;
 

--- a/src/modules/requests/requests.interface.ts
+++ b/src/modules/requests/requests.interface.ts
@@ -9,6 +9,7 @@ export interface Create {
 
 export interface UpdateStatus {
   status: number;
+  notes: string;
 }
 export interface UpdateItem {
   item_name: string;
@@ -20,4 +21,9 @@ export interface UpdateItem {
 export interface UpdateFilename {
   filename: string;
   status: number;
+}
+
+export interface UpdateNotes {
+  status: number;
+  notes: string;
 }

--- a/src/modules/requests/requests.repository.ts
+++ b/src/modules/requests/requests.repository.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Request } from '../../entities/request.entity';
 import { UserAccess } from '../../common/interfaces/keycloak-user.interface';
 import { Pagination } from '../../common/interfaces/pagination.interface';
-import { UpdateFilename, UpdateItem } from './requests.interface';
+import { UpdateFilename, UpdateItem, UpdateNotes } from './requests.interface';
 export class RequestsRepository {
   constructor(
     @InjectRepository(Request)
@@ -48,6 +48,10 @@ export class RequestsRepository {
   }
 
   updateFilePath(id: string, updated: UpdateFilename) {
+    return this.request.update(id, updated);
+  }
+
+  updateNotes(id: string, updated: UpdateNotes) {
     return this.request.update(id, updated);
   }
 }

--- a/src/modules/requests/requests.rules.ts
+++ b/src/modules/requests/requests.rules.ts
@@ -1,6 +1,7 @@
 import Joi from 'joi';
+import { status } from '../../common/helpers/status';
 
-export const CreateRequestPayloadSchema = Joi.object({
+export const CreatePayloadSchema = Joi.object({
   division: Joi.string().required(),
   phone_number: Joi.string().required(),
   request_type: Joi.number().strict().required(),
@@ -11,17 +12,25 @@ export const CreateRequestPayloadSchema = Joi.object({
 
 const emptyAllow = ['', null];
 
-export const GetRequestsSchema = Joi.object({
+export const FindAllPayloadSchema = Joi.object({
   limit: Joi.number().allow(...emptyAllow),
   page: Joi.number().allow(...emptyAllow),
 });
 
-export const ChangeRequestPayloadSchema = Joi.object({
+export const UpdateStatusPayloadSchema = Joi.object({
   status: Joi.number().strict().required(),
 });
 
-export const PatchRequestItemPayloadSchema = Joi.object({
+export const UpdateItemPayloadSchema = Joi.object({
   item_name: Joi.string().required(),
   item_brand: Joi.string().required(),
   item_number: Joi.string().required(),
+});
+
+export const UpdateNotesPayloadSchema = Joi.object({
+  status: Joi.number()
+    .strict()
+    .equal(status.REJECTED, status.ELIGIBILITY_CHECK)
+    .required(),
+  notes: Joi.string().required(),
 });

--- a/src/modules/requests/requests.service.ts
+++ b/src/modules/requests/requests.service.ts
@@ -10,6 +10,7 @@ import {
   UpdateStatus,
   UpdateItem,
   UpdateFilename,
+  UpdateNotes,
 } from './requests.interface';
 import { QueryPagination } from '../../common/interfaces/pagination.interface';
 import { status } from '../../common/helpers/status';
@@ -78,5 +79,9 @@ export class RequestsService {
     };
 
     return this.repo.updateItem(id, updated);
+  }
+
+  updateNotes(id: string, updateNotes: UpdateNotes) {
+    return this.repo.updateNotes(id, updateNotes);
   }
 }


### PR DESCRIPTION
# Overview
- Create update notes api only for set update on rejected and eligibility check process by admin

on error:
<img width="1124" alt="Screen Shot 2022-10-28 at 14 15 37" src="https://user-images.githubusercontent.com/113004112/198526729-46db10ad-7b55-441d-b21d-c5dbdde5cca6.png">

on succes:
<img width="1124" alt="Screen Shot 2022-10-28 at 14 15 55" src="https://user-images.githubusercontent.com/113004112/198526774-8ca4f7d7-9910-44e0-b40e-33d1504ab0ef.png">

## Link / Related Issue

## Todo
- Upload Evidence File service

## Evidence
- Title: feat: update notes api
- Project: Digiteam Inventaris Platform
- Participants: @iqbal167 @ayocodingit @azophy @muhamadabduh 
