### PR TITLE
fix: Property 'offset' does not exist on type 'FindAll'.

### DIFF
--- a/src/common/helpers/pagination.ts
+++ b/src/common/helpers/pagination.ts
@@ -1,10 +1,6 @@
-import {
-  MetaPagination,
-  Pagination,
-  QueryPagination,
-} from '../interfaces/pagination.interface';
+import { MetaPagination, Pagination } from '../interfaces/pagination.interface';
 
-export const queryPagination = (request: QueryPagination): Pagination => {
+export const queryPagination = (request: Pagination): Pagination => {
   const limit = Number(request.limit) || 10;
   const page = Number(request.page) || 1;
   const offset = (page - 1) * limit;

--- a/src/common/interfaces/pagination.interface.ts
+++ b/src/common/interfaces/pagination.interface.ts
@@ -1,12 +1,7 @@
-export interface QueryPagination {
+export interface Pagination {
   page?: number;
   limit?: number;
-}
-
-export interface Pagination {
-  page: number;
-  limit: number;
-  offset: number;
+  offset?: number;
 }
 
 export interface MetaPagination {

--- a/src/modules/files/files.controller.ts
+++ b/src/modules/files/files.controller.ts
@@ -20,7 +20,6 @@ export class FilesController {
   @Post('upload')
   @UseInterceptors(FileInterceptor('file', multerOptions))
   async upload(
-    @Param('id') id: string,
     @UploadedFile() file: Express.Multer.File,
     @Res() res: Response,
   ) {

--- a/src/modules/requests/requests.interface.ts
+++ b/src/modules/requests/requests.interface.ts
@@ -1,4 +1,4 @@
-import { QueryPagination } from 'src/common/interfaces/pagination.interface';
+import { Pagination } from 'src/common/interfaces/pagination.interface';
 
 export interface Create {
   division: string;
@@ -22,7 +22,7 @@ export interface Update {
   pickup_bast?: string;
 }
 
-export interface FindAll extends QueryPagination {
+export interface FindAll extends Pagination {
   sort_by?: string;
   sort?: 'asc' | 'desc';
   request_type?: number;

--- a/src/modules/requests/requests.service.ts
+++ b/src/modules/requests/requests.service.ts
@@ -31,7 +31,7 @@ export class RequestsService {
       limit: queryParams.limit,
     });
 
-    const findAll = {
+    const findAll: FindAll = {
       ...queryParams,
       ...pagination,
     };


### PR DESCRIPTION
# Overview
- fix `Property 'offset' does not exist on type 'FindAll'.`

## Link / Related Issue

## Todo

## Evidence
- Title: fix: Property 'offset' does not exist on type 'FindAll'.
- Project: Digiteam Inventaris Platform
- Participants: @iqbal167 @ayocodingit @rhmnmbr83 @ayocodingit 