### PR TITLE
fix: request update validation 

### DIFF
--- a/src/modules/requests/requests.controller.ts
+++ b/src/modules/requests/requests.controller.ts
@@ -37,6 +37,7 @@ export class RequestsController {
     @Res() res: Response,
   ): Promise<any> {
     const userAccess = this.rolesService.getUserAccess(authUser);
+
     this.requestsService.store(create, userAccess);
 
     return res.status(HttpStatus.CREATED).send({
@@ -76,6 +77,7 @@ export class RequestsController {
     @Res() res: Response,
   ) {
     this.requestsService.update(id, update);
+
     return res.status(HttpStatus.OK).send({
       message: 'UPDATED',
     });

--- a/src/modules/requests/requests.rules.ts
+++ b/src/modules/requests/requests.rules.ts
@@ -27,45 +27,45 @@ export const FindAllPayloadSchema = Joi.object({
 });
 
 export const UpdatePayloadSchema = Joi.object({
-  status: Joi.number().strict().equal(),
+  status: Joi.number().strict().required(),
   notes: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.REJECTED, status.CHECKED),
+    is: Joi.equal(status.REJECTED, status.READY),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   filename: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.APPROVED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   item_name: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.REQUESTED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   item_brand: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.REQUESTED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   item_number: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.REQUESTED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   pickup_signing: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.RECEIVED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   pickup_evidence: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.RECEIVED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
   pickup_bast: Joi.alternatives().conditional('status', {
     is: Joi.equal(status.RECEIVED),
     then: Joi.string().required(),
-    otherwise: Joi.forbidden(),
+    otherwise: Joi.any().strip(),
   }),
 });

--- a/src/modules/requests/requests.rules.ts
+++ b/src/modules/requests/requests.rules.ts
@@ -5,6 +5,14 @@ const emptyAllow = ['', null];
 const sortByAllow = ['created_at', 'division', 'status', 'request_type'];
 const sort = ['asc', 'desc'];
 
+const setStatusWhenOption = (status: number[]): Joi.WhenOptions => {
+  return {
+    is: Joi.equal(...status),
+    then: Joi.string().required(),
+    otherwise: Joi.any().strip(),
+  };
+};
+
 export const CreatePayloadSchema = Joi.object({
   division: Joi.string().required(),
   phone_number: Joi.string().required(),
@@ -28,44 +36,36 @@ export const FindAllPayloadSchema = Joi.object({
 
 export const UpdatePayloadSchema = Joi.object({
   status: Joi.number().strict().required(),
-  notes: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.REJECTED, status.READY),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  filename: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.APPROVED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  item_name: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.REQUESTED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  item_brand: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.REQUESTED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  item_number: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.REQUESTED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  pickup_signing: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.RECEIVED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  pickup_evidence: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.RECEIVED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
-  pickup_bast: Joi.alternatives().conditional('status', {
-    is: Joi.equal(status.RECEIVED),
-    then: Joi.string().required(),
-    otherwise: Joi.any().strip(),
-  }),
+  notes: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.REJECTED, status.READY]),
+  ),
+  filename: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.APPROVED]),
+  ),
+  item_name: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.REQUESTED]),
+  ),
+  item_brand: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.REQUESTED]),
+  ),
+  item_number: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.REQUESTED]),
+  ),
+  pickup_signing: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.RECEIVED]),
+  ),
+  pickup_evidence: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.RECEIVED]),
+  ),
+  pickup_bast: Joi.alternatives().conditional(
+    'status',
+    setStatusWhenOption([status.RECEIVED]),
+  ),
 });


### PR DESCRIPTION
# Overview
- fix improperly set status
- change on otherwise from forbidden to strip
- DRY set when option object

## Link / Related Issue
- when notes is required, the status should be `REJECTED` or `READY`

## Todo
- Update README.md

## Evidence
- Title: fix: request update validation 
- Project: Digiteam Inventaris Platform
- Participants: @iqbal167 @ayocodingit @sandisunandar99 @rachadiannovansyah @indraprasetya154 