### PR TITLE
refactor: move sso/ and storage/ to src/providers directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,33 +57,34 @@ npm run start:dev
 ## Repo Structure
 
 ```bash
-.github/
-└── workflows
-docker
-src/
-├── common/
-│   ├── exceptions
-│   ├── helpers
-│   ├── interceptors
-│   ├── interfaces
-│   ├── lang
-│   ├── logger
-│   └── pipes
-├── config
-├── database/
-│   ├── migrations
-│   ├── mysql
-│   └── orm
-├── entities
-├── modules/
-│   └── <module_name>/
-│       ├── <module_name>.controller
-│       ├── <module_name>.interface
-│       ├── <module_name>.module
-│       ├── <module_name>.repository
-│       ├── <module_name>.rules
-│       └── <module_name>.service  
-├── sso/
-│   └── keycloak
-└── storage
+.
+├── .github/
+│   └── workflows
+├── docker
+└── src/
+    ├── common/
+    │   ├── exceptions
+    │   ├── helpers
+    │   ├── interceptors
+    │   ├── interfaces
+    │   ├── lang
+    │   ├── logger
+    │   └── pipes
+    ├── config
+    ├── database/
+    │   ├── migrations
+    │   ├── mysql
+    │   └── orm
+    ├── entities
+    ├── modules/
+    │   └── <module_name>/
+    │       ├── <module_name>.controller 
+    │       ├── <module_name>.interface
+    │       ├── <module_name>.module
+    │       ├── <module_name>.respository
+    │       ├── <module_name>.rules
+    │       └── <module_name>.service  
+    └── providers/
+        ├── sso
+        └── storage
 ```

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { RequestsModule } from './modules/requests/requests.module';
-import { KeycloakClientModule } from './sso/keycloak/keycloak.module';
+import { KeycloakClientModule } from './providers/sso/keycloak/keycloak.module';
 import { ExceptionModule } from './common/exceptions/exception.module';
 import { MysqlClientModule } from './database/mysql/mysql.module';
 import { AuthenticationsModule } from './modules/authentications/authentications.module';

--- a/src/modules/authentications/authentications.module.ts
+++ b/src/modules/authentications/authentications.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { KeycloakRolesService } from 'src/sso/keycloak/roles.provider';
+import { KeycloakRolesService } from '../../providers/sso/keycloak/roles.provider';
 import { AuthenticationsController } from './authentications.controller';
 import { AuthenticationsService } from './authentications.service';
 

--- a/src/modules/authentications/authentications.service.ts
+++ b/src/modules/authentications/authentications.service.ts
@@ -4,7 +4,7 @@ import {
   AuthUser,
   UserAccess,
 } from 'src/common/interfaces/keycloak-user.interface';
-import { KeycloakRolesService } from 'src/sso/keycloak/roles.provider';
+import { KeycloakRolesService } from '../../providers/sso/keycloak/roles.provider';
 
 @Injectable()
 export class AuthenticationsService {

--- a/src/modules/files/files.module.ts
+++ b/src/modules/files/files.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { FilesController } from './files.controller';
-import { MinioClientModule } from './../../storage/minio/minio.module';
+import { MinioClientModule } from '../../providers/storage/minio/minio.module';
 import { FilesService } from './files.service';
 import { HttpModule } from '@nestjs/axios';
 

--- a/src/modules/files/files.service.ts
+++ b/src/modules/files/files.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { MinioClientService } from 'src/storage/minio/minio.service';
+import { MinioClientService } from '../../providers/storage/minio/minio.service';
 import { HttpService } from '@nestjs/axios';
 import { lastValueFrom } from 'rxjs';
 import { ConfigService } from '@nestjs/config';

--- a/src/modules/requests/requests.controller.ts
+++ b/src/modules/requests/requests.controller.ts
@@ -20,7 +20,7 @@ import {
 import { AuthenticatedUser } from 'nest-keycloak-connect';
 import { AuthUser } from '../../common/interfaces/keycloak-user.interface';
 import { Update, Create, FindAll } from './requests.interface';
-import { KeycloakRolesService } from 'src/sso/keycloak/roles.provider';
+import { KeycloakRolesService } from '../../providers/sso/keycloak/roles.provider';
 
 @Controller('requests')
 export class RequestsController {

--- a/src/modules/requests/requests.module.ts
+++ b/src/modules/requests/requests.module.ts
@@ -5,7 +5,7 @@ import { RequestsController } from './requests.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Request } from '../../entities/request.entity';
 import { RequestsRepository } from './requests.repository';
-import { KeycloakRolesService } from 'src/sso/keycloak/roles.provider';
+import { KeycloakRolesService } from '../../providers/sso/keycloak/roles.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Request])],

--- a/src/modules/requests/requests.service.spec.ts
+++ b/src/modules/requests/requests.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RequestsService } from './requests.service';
 import { RequestsRepository } from './requests.repository';
-import { MinioClientModule } from '../../storage/minio/minio.module';
+import { MinioClientModule } from '../../providers/storage/minio/minio.module';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Request } from '../../entities/request.entity';
 import { Repository } from 'typeorm';

--- a/src/providers/sso/keycloak/keycloak.module.ts
+++ b/src/providers/sso/keycloak/keycloak.module.ts
@@ -2,7 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { Module } from '@nestjs/common';
 import { KeycloakConnectModule, AuthGuard } from 'nest-keycloak-connect';
 import { APP_GUARD } from '@nestjs/core';
-import { AppConfigModule } from '../../config/config.module';
+import { AppConfigModule } from '../../../config/config.module';
 
 @Module({
   imports: [

--- a/src/providers/sso/keycloak/roles.guard.ts
+++ b/src/providers/sso/keycloak/roles.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
-import { AuthUser } from '../../common/interfaces/keycloak-user.interface';
+import { AuthUser } from '../../../common/interfaces/keycloak-user.interface';
 import { KeycloakRolesService } from './roles.provider';
 
 @Injectable()

--- a/src/providers/sso/keycloak/roles.provider.ts
+++ b/src/providers/sso/keycloak/roles.provider.ts
@@ -1,10 +1,10 @@
 import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
-import { RoleAccess } from '../../common/interfaces/role-access.interface';
+import { RoleAccess } from '../../../common/interfaces/role-access.interface';
 import {
   AuthUser,
   UserAccess,
-} from '../../common/interfaces/keycloak-user.interface';
+} from '../../../common/interfaces/keycloak-user.interface';
 
 @Injectable()
 export class KeycloakRolesService {

--- a/src/providers/storage/minio/minio.module.ts
+++ b/src/providers/storage/minio/minio.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MinioModule } from 'nestjs-minio-client';
-import { AppConfigModule } from '../../config/config.module';
+import { AppConfigModule } from '../../../config/config.module';
 import { MinioClientService } from './minio.service';
 
 @Module({

--- a/src/providers/storage/minio/minio.service.ts
+++ b/src/providers/storage/minio/minio.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MinioService } from 'nestjs-minio-client';
-import { createFileObject } from './../../common/helpers/upload';
+import { createFileObject } from '../../../common/helpers/upload';
 
 @Injectable()
 export class MinioClientService {


### PR DESCRIPTION
# Overview
- move `sso/` and `storage/` to `src/providers` directory

## Link / Related Issue

## Todo

## Evidence
- Title: refactor: move sso/ and storage/ to src/providers directory
- Project: Digiteam Inventaris Platform
- Participants: @iqbal167 @ayocodingit @rindibudiaramdhan @fajarhikmal214 @rhmnmbr83 @indraprasetya154 